### PR TITLE
Checking if append blobs exist before appending to them

### DIFF
--- a/src/Sitecore.Azure.Diagnostics/Appenders/AzureBlobStorageAppender.cs
+++ b/src/Sitecore.Azure.Diagnostics/Appenders/AzureBlobStorageAppender.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using log4net.Appender;
 using log4net.spi;
+using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using Sitecore.Azure.Diagnostics.Storage;
 
@@ -105,8 +106,24 @@ namespace Sitecore.Azure.Diagnostics.Appenders
       var blob = this.Blob as CloudAppendBlob;
       string message = this.RenderLoggingEvent(loggingEvent);
 
+      CreateBlobIfNotExists(blob);
       blob.AppendText(message);
     }    
+
+    /// <summary>
+    /// Creates a new blob for the specified <see cref="CloudAppendBlob" /> if it does not already exist.
+    /// </summary>
+    /// <param name="blob">The <see cref="CloudAppendBlob" />.</param>
+    /// <param name="accessCondition">The access condition.</param>
+    /// <param name="blobRequestOptions">The blob request options.</param>
+    /// <param name="operationContext">The operation context.</param>
+    protected static void CreateBlobIfNotExists(CloudAppendBlob blob, AccessCondition accessCondition = null, BlobRequestOptions blobRequestOptions = null, OperationContext operationContext = null)
+    {
+        if (!blob.Exists(blobRequestOptions, operationContext))
+        {
+            blob.CreateOrReplace(accessCondition, blobRequestOptions, operationContext);
+        }
+    }
 
     /// <summary>
     /// Gets the new cloud blob for diagnostic messages.


### PR DESCRIPTION
Hey Oleg,

I implemented the Sitecore.Azure.Diagnostics in our project to facilitate writing the log files to Azure Storage. Because we are using Sitecore 8.1, the current NuGet package (7.5.0) doet not fulfill our needs so I compiled your source code from GitHub which had excellent results. Unfortunately the code did not initially produce results: because no blobs were present in Azure Storage, the Appender could not write to them. For this I have added a check into the code to make sure the Append Blob is present before the actual Appending proceeds. Feel free to use the code from this Pull Request in your project.

Kind regards,
Pieter-Paul Luijten
